### PR TITLE
Add libbz2-dev to dependencies, so bz2 module is built in py3.6.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:16.04
 # Install the depdencies in the repo.
 RUN apt-get -y update && apt-get -y install python-pip python3-pip \
     git openssh-server postgresql-client libpq-dev python3-dev \
-    libsqlite3-dev libmysqlclient-dev libreadline-dev python-dev
+    libsqlite3-dev libmysqlclient-dev libreadline-dev libbz2-dev \
+    python-dev
 
 
 # Install latest version of tox.


### PR DESCRIPTION
The python 3.6 binary built by this Dockerfile lacks the bz2 module. See https://gitlab.com/J08nY/mailman-pgp/-/jobs/19246384 for example. This adds the required dependency so it is found by configure and built into the python 3.6 binary.